### PR TITLE
Rewrote player payload logic

### DIFF
--- a/ChatBubbles/OnChat.cs
+++ b/ChatBubbles/OnChat.cs
@@ -22,14 +22,23 @@ namespace ChatBubbles
             var nline = new SeString(new List<Payload>());
             nline.Payloads.Add(new TextPayload("\n"));
             fmessage.Append(cmessage);
-            
+
             //Stolen from Dragon (SheepGoMeh)
-            var playerPayload = sender.Payloads.SingleOrDefault(x => x is PlayerPayload) as PlayerPayload;
+            PlayerPayload playerPayload;
+
+            if (sender.ToString() == _clientState.LocalPlayer.Name.TextValue) 
+            {
+                //We already know the sender is the local player.
+                playerPayload = new PlayerPayload(_clientState.LocalPlayer.Name.TextValue, _clientState.LocalPlayer.HomeWorld.Id); 
+            }
+            else 
+            { 
+                playerPayload = sender.Payloads.SingleOrDefault(x => x is PlayerPayload) as PlayerPayload ?? cmessage.Payloads.FirstOrDefault(x => x is PlayerPayload) as PlayerPayload;
+            }
+
             var isEmoteType = type is XivChatType.CustomEmote or XivChatType.StandardEmote;
             if (isEmoteType)
             {
-                //Only need this for standard emotes. It breaks custom emotes.
-                if (type is XivChatType.StandardEmote) playerPayload = cmessage.Payloads.FirstOrDefault(x => x is PlayerPayload) as PlayerPayload;
                 fmessage.Payloads.Insert(0, new EmphasisItalicPayload(true));
                 fmessage.Payloads.Add(new EmphasisItalicPayload(false));
             }


### PR DESCRIPTION
There were some edge cases that were still not determining the correct player (standard emotes that were targeted were ignoring the "You" part of the message when searching the cmessage payload for example.)

This should more consistently determine the sending player to place a chat bubble over.

The only case left is when a player from another server has the same name as the current player, but I am unsure how to resolve this. Dalamud doesn't seem to consistently append a home world in the sender parameter, but I believe characters with the same names will always be a bit odd right now due to the way GetActorId works. 

It's a rare enough situation to potentially just not worry about handling it, but also something that could be looked into later.

