### PR TITLE
Handle null reference exception

### DIFF
--- a/ChatBubbles/OnceUponAFrame.cs
+++ b/ChatBubbles/OnceUponAFrame.cs
@@ -182,10 +182,15 @@ namespace ChatBubbles
                     PluginLog.Log($"Error while updating frame: {e}");
                 }
 
-                if (addonPtr2 != IntPtr.Zero)
+                if (addonPtr2 != IntPtr.Zero && bubblesAtk2 is not null)
                 {
                     for (int u = 0; u < 10; u++)
                     {
+                        if (bubblesAtk2[u] is null)
+                        {
+                            break;
+                        }
+
                         if (!bubblesAtk2[u]->IsVisible)
                         {
                             bubbleActive[u] = false;


### PR DESCRIPTION
Resolves the following error by checking for null pointers before trying to access objects.

```
[ChatBubbles] Error before updating frame: System.NullReferenceException: Object reference not set to an instance of an object.
   at FFXIVClientStructs.FFXIV.Component.GUI.AtkResNode.get_IsVisible() in D:\a\Dalamud\Dalamud\lib\FFXIVClientStructs\FFXIVClientStructs\FFXIV\Component\GUI\AtkResNode.cs:line 104
   at ChatBubbles.ChatBubbles.OnceUponAFrame(Object _) in /work/repo/ChatBubbles/OnceUponAFrame.cs:line 189
```